### PR TITLE
fix: update scrollTo logic on tab switch

### DIFF
--- a/src/FlashList.tsx
+++ b/src/FlashList.tsx
@@ -71,7 +71,7 @@ function FlashListImpl<R>(
   const ref = useSharedAnimatedRef<any>(passRef)
   const recyclerRef = useSharedAnimatedRef<any>(null)
 
-  const { scrollHandler, enable } = useScrollHandlerY(name)
+  const { scrollHandler, enable } = useScrollHandlerY(name, true)
 
   const hadLoad = useSharedValue(false)
 

--- a/src/MasonryFlashList.tsx
+++ b/src/MasonryFlashList.tsx
@@ -74,7 +74,7 @@ function MasonryFlashListImpl<R>(
   const recyclerRef = useSharedAnimatedRef<any>(null)
   const ref = useSharedAnimatedRef<any>(passRef)
 
-  const { scrollHandler, enable } = useScrollHandlerY(name)
+  const { scrollHandler, enable } = useScrollHandlerY(name, true)
 
   const hadLoad = useSharedValue(false)
 


### PR DESCRIPTION
This PR fixes the issue when switching tabs can cause the scroll position of the next tab to either be stuck in the wrong position or to jump to place in a delay. 

There are two parts to this change.

1. We moved the scrollTo logic from the enable callback to a [useAnimatedReaction based on focusedTab.value](https://github.com/AndreiCalazans/react-native-collapsible-tab-view/pull/1/files#diff-e1885f2bb836eadfd0ba8c3188d702dddcb31ca48ea5fb9174247fac2fe0bb0fR306-R307)
2. [The addition of an extra layer](https://github.com/AndreiCalazans/react-native-collapsible-tab-view/pull/1/files#diff-e1885f2bb836eadfd0ba8c3188d702dddcb31ca48ea5fb9174247fac2fe0bb0fR283-R304) of logic particularly for FlashList to run a sequence of scheduled scrollTo s avoid frame dropping and showing to the user the scroll jump. This is controlled by the shouldScheduleScrollSync option.


